### PR TITLE
fix typo

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -11,13 +11,13 @@ pub fn main() !void {
     defer client.stream.close();
 
     var sender_thread = try std.Thread.spawn(.{}, sender, .{&client.stream});
-    var reciever_thread = try std.Thread.spawn(.{}, reciever, .{&client.stream});
+    var receiver_thread = try std.Thread.spawn(.{}, receiver, .{&client.stream});
 
     sender_thread.join();
-    reciever_thread.join();
+    receiver_thread.join();
 }
 
-fn reciever(stream: *std.net.Stream) !void {
+fn receiver(stream: *std.net.Stream) !void {
     const stdout = std.io.getStdOut().writer();
     const reader = stream.reader();
     while (true) {


### PR DESCRIPTION
This pull request includes a minor fix to correct a typo in the `src/main.zig` file. The typo in the function name and variable name `reciever` was corrected to `receiver`.

* Typo correction:
  * Renamed `reciever_thread` to `receiver_thread` and `reciever` to `receiver` in `src/main.zig`.